### PR TITLE
Allow smvs to run on older hardware

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,7 +1,7 @@
 TARGET := smvsrecon
 include ../Makefile.inc
 
-CXXFLAGS += -I${MVE_ROOT}/libs -I../lib -msse4.2 -pthread -std=c++11
+CXXFLAGS += -I${MVE_ROOT}/libs -I../lib -march=native -pthread -std=c++11
 LDLIBS += -lpng -ltiff -ljpeg -lpthread
 
 SOURCES := $(wildcard [^_]*.cc)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,7 +1,7 @@
 TARGET := libsmvs.a
 include ../Makefile.inc
 
-CXXFLAGS += -I${MVE_ROOT}/libs -I../lib -msse4.2 -pthread
+CXXFLAGS += -I${MVE_ROOT}/libs -I../lib -march=native -pthread
 LDLIBS += -lpng -ltiff -ljpeg -pthread
 
 SOURCES := $(wildcard [^_]*.cc)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@
 TARGET = all
 include ../Makefile.inc
 
-CXXFLAGS += -I${MVE_ROOT}/libs -I../lib -msse4.2 -pthread -std=c++11
+CXXFLAGS += -I${MVE_ROOT}/libs -I../lib -march=native -pthread -std=c++11
 LDLIBS += -lpng -ltiff -ljpeg -lpthread
 
 SOURCES := $(wildcard [^_]*.cc)


### PR DESCRIPTION
Hello :hand:

This PR proposes to remove the `-msse4.2` flag (which is specific only to certain hardware) and replace it with `-march=native`, which will select the optimizations (including sse4.2) that are available on the machine.

A similar fix was done some time ago for MVE (see https://github.com/simonfuhrmann/mve/pull/441).
